### PR TITLE
Add React frontend and Express server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# spa_grad
+# SPA Grad
+
+This project provides a simple interface to view student information stored in a Google Sheet. A small Express server exposes API endpoints and a React frontend consumes them.
+
+## Setup
+
+1. Install dependencies (from the project root):
+   ```bash
+   npm install
+   npm --prefix client install
+   ```
+
+2. Configure your Google service account credentials and spreadsheet ID via environment variables:
+   - `GOOGLE_SERVICE_ACCOUNT_JSON` or `GOOGLE_SERVICE_ACCOUNT_FILE`
+   - `SPREADSHEET_ID`
+   - `SHEET_NAME` (optional, defaults to `Sheet1`)
+
+3. Run the development servers:
+   ```bash
+   npm run dev
+   ```
+   The Express API runs on port `3000` and the React application on port `5173` with proxying to the API.
+
+4. Build the frontend for production:
+   ```bash
+   npm --prefix client run build
+   ```
+   Then start the server with `npm start` to serve the built files.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SPA Grad</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "spa_grad_client",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react'
+
+function App() {
+  const [students, setStudents] = useState([])
+
+  useEffect(() => {
+    fetch('/api/students')
+      .then(res => res.json())
+      .then(setStudents)
+      .catch(err => console.error(err))
+  }, [])
+
+  return (
+    <div>
+      <h1>Student List</h1>
+      <ul>
+        {students.map(student => (
+          <li key={student.ID}>
+            {student.Firstname} {student.Lastname} - {student.Course}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default App

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,4 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+}

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000'
+    }
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "spa_grad",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.js",
+    "client": "npm --prefix client run dev",
+    "dev": "concurrently \"npm run start\" \"npm run client\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "googleapis": "^132.0.0"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const path = require('path');
+const { getAllStudents } = require('./sheets');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+
+app.get('/api/students', async (req, res) => {
+  try {
+    const students = await getAllStudents();
+    res.json(students);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch students' });
+  }
+});
+
+app.use(express.static(path.join(__dirname, 'client', 'dist')));
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'client', 'dist', 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add package.json for server
- implement Express server exposing student API
- create React frontend with Vite
- document setup steps in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687060574acc832a9e197e704cad9906