### PR TITLE
Add AwardScreen to manage certificate collection

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import Menu from './Menu'
 import StudentList from './StudentList'
 import AttendanceForm from './AttendanceForm'
 import GownManagement from './GownManagement'
+import AwardScreen from './AwardScreen'
 
 export default function App() {
   return (
@@ -13,6 +14,7 @@ export default function App() {
         <Route path="/" element={<StudentList />} />
         <Route path="/attendance" element={<AttendanceForm />} />
         <Route path="/gown" element={<GownManagement />} />
+        <Route path="/award" element={<AwardScreen />} />
       </Routes>
     </Router>
   )

--- a/client/src/AwardScreen.jsx
+++ b/client/src/AwardScreen.jsx
@@ -1,0 +1,57 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import './index.css'
+
+export default function AwardScreen() {
+  const [students, setStudents] = useState([])
+
+  const loadStudents = useCallback(() => {
+    fetch('/api/students')
+      .then(res => res.json())
+      .then(data => {
+        const filtered = data
+          .filter(s => s.StudentAttended === 'Yes' && s.AwardStatus !== 'Collected')
+          .sort((a, b) => a.ID - b.ID)
+          .slice(0, 3)
+        setStudents(filtered)
+      })
+      .catch(err => console.error(err))
+  }, [])
+
+  useEffect(() => {
+    loadStudents()
+    const interval = setInterval(loadStudents, 5000)
+    window.addEventListener('focus', loadStudents)
+    return () => {
+      clearInterval(interval)
+      window.removeEventListener('focus', loadStudents)
+    }
+  }, [loadStudents])
+
+  const markCollected = id => {
+    fetch(`/api/students/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ AwardStatus: 'Collected' })
+    })
+      .then(() => loadStudents())
+      .catch(err => console.error(err))
+  }
+
+  return (
+    <div className="container">
+      <h1>Award Collection</h1>
+      <div className="grid">
+        {students.map(s => (
+          <div key={s.ID} className="card">
+            {s.StudentPicture && (
+              <img src={s.StudentPicture} alt={s.Firstname} className="photo" />
+            )}
+            <h3>{s.Firstname} {s.Lastname}</h3>
+            <p>{s.Course}</p>
+            <button onClick={() => markCollected(s.ID)}>Mark Certificate Collected</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/client/src/Menu.jsx
+++ b/client/src/Menu.jsx
@@ -8,6 +8,7 @@ export default function Menu() {
       <Link to="/">Students</Link>
       <Link to="/attendance">Attendance</Link>
       <Link to="/gown">Gown Mgmt</Link>
+      <Link to="/award">Awards</Link>
     </nav>
   )
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -61,3 +61,23 @@ body {
   font-family: Arial, sans-serif;
   padding: 20px;
 }
+
+.grid {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.card {
+  border: 1px solid #ddd;
+  padding: 1rem;
+  border-radius: 4px;
+  width: 200px;
+}
+
+.photo {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}

--- a/server.js
+++ b/server.js
@@ -49,6 +49,9 @@ app.put('/api/students/:id', async (req, res) => {
     if (req.body.GownDownpaymentType !== undefined) {
       updates.push(updateStudentField(id, 'GownDownpaymentType', req.body.GownDownpaymentType));
     }
+    if (req.body.AwardStatus !== undefined) {
+      updates.push(updateStudentField(id, 'AwardStatus', req.body.AwardStatus));
+    }
     await Promise.all(updates);
     const student = await getStudentById(id);
     res.json(student);


### PR DESCRIPTION
## Summary
- add new AwardScreen component to show next students for award collection
- support AwardStatus updates in server
- include AwardScreen in routing and menu
- style award grid and cards

## Testing
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_687078c12384832aa7e45f5109810b98