### PR TITLE
Update Guests Attended on save

### DIFF
--- a/AttendanceForm.jsx
+++ b/AttendanceForm.jsx
@@ -55,6 +55,10 @@ export default function AttendanceForm() {
     if (guestNumber !== selectedStudent.GuestNumber) {
       updates.push(updateStudentField(selectedStudent.ID, 'GuestNumber', guestNumber));
     }
+    // also update Guests Attended to match the number entered
+    if (guestNumber !== selectedStudent.GuestAttended) {
+      updates.push(updateStudentField(selectedStudent.ID, 'GuestAttended', guestNumber));
+    }
     const attendedValue = studentAttended ? 'Yes' : 'No';
     if (attendedValue !== selectedStudent.StudentAttended) {
       updates.push(updateStudentField(selectedStudent.ID, 'StudentAttended', attendedValue));

--- a/client/src/AttendanceForm.jsx
+++ b/client/src/AttendanceForm.jsx
@@ -47,14 +47,15 @@ export default function AttendanceForm() {
   const handleSubmit = e => {
     e.preventDefault()
     if (!selectedId) return
-    Promise.all([
-      updateStudentField(selectedId, 'GuestNumber', guestNumber),
-      updateStudentField(
-        selectedId,
-        'StudentAttended',
-        studentAttended ? 'Yes' : 'No'
-      )
-    ])
+    const updates = []
+    if (guestNumber !== selectedStudent.GuestNumber)
+      updates.push(updateStudentField(selectedId, 'GuestNumber', guestNumber))
+    if (guestNumber !== selectedStudent.GuestAttended)
+      updates.push(updateStudentField(selectedId, 'GuestAttended', guestNumber))
+    const attendedVal = studentAttended ? 'Yes' : 'No'
+    if (attendedVal !== selectedStudent.StudentAttended)
+      updates.push(updateStudentField(selectedId, 'StudentAttended', attendedVal))
+    Promise.all(updates)
       .then(() => loadStudent(selectedId))
       .then(() => setMessage({ type: 'success', text: 'Saved successfully' }))
       .catch(() => setMessage({ type: 'error', text: 'Failed to save changes' }))

--- a/server.js
+++ b/server.js
@@ -40,6 +40,9 @@ app.put('/api/students/:id', async (req, res) => {
     if (req.body.GuestNumber !== undefined) {
       updates.push(updateStudentField(id, 'GuestNumber', req.body.GuestNumber));
     }
+    if (req.body.GuestAttended !== undefined) {
+      updates.push(updateStudentField(id, 'GuestAttended', req.body.GuestAttended));
+    }
     if (req.body.StudentAttended !== undefined) {
       updates.push(updateStudentField(id, 'StudentAttended', req.body.StudentAttended));
     }


### PR DESCRIPTION
## Summary
- persist Guests Attended value from Attendance form
- send GuestAttended field in API calls

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix client test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687085c2a4e8832aab0ee3fa1f61e447