### PR TITLE
Fix large image uploads

### DIFF
--- a/client/src/AttendanceForm.jsx
+++ b/client/src/AttendanceForm.jsx
@@ -72,7 +72,30 @@ export default function AttendanceForm() {
     const file = e.target.files[0]
     if (file) {
       const reader = new FileReader()
-      reader.onloadend = () => setPhoto(reader.result)
+      reader.onload = () => {
+        const img = new Image()
+        img.onload = () => {
+          const canvas = document.createElement('canvas')
+          const maxSize = 400
+          let { width, height } = img
+          if (width > height) {
+            if (width > maxSize) {
+              height *= maxSize / width
+              width = maxSize
+            }
+          } else if (height > maxSize) {
+            width *= maxSize / height
+            height = maxSize
+          }
+          canvas.width = width
+          canvas.height = height
+          const ctx = canvas.getContext('2d')
+          ctx.drawImage(img, 0, 0, width, height)
+          const dataUrl = canvas.toDataURL('image/jpeg', 0.7)
+          setPhoto(dataUrl)
+        }
+        img.src = reader.result
+      }
       reader.readAsDataURL(file)
     }
   }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -77,6 +77,7 @@ body {
 
 .photo {
   width: 100%;
+  max-width: 200px;
   height: auto;
   border-radius: 4px;
   margin-bottom: 0.5rem;

--- a/server.js
+++ b/server.js
@@ -7,7 +7,8 @@ const { getAllStudents, getStudentById, updateStudentField } = require('./sheets
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.use(express.json());
+// Increase body limit to handle base64 encoded images
+app.use(express.json({ limit: '5mb' }));
 
 app.get('/api/students', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- scale uploaded photo client-side
- limit Express JSON payload size to allow small base64 images
- keep images small in the UI

## Testing
- `npm --prefix client run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68708c0830e4832aad7bba836f9bd7d9