### PR TITLE
Add attendee list page with gown status

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import GownManagement from './GownManagement'
 import AwardScreen from './AwardScreen'
 import AwardDisplay from './AwardDisplay'
 import ReportScreen from './ReportScreen'
+import AttendeeTable from './AttendeeTable'
 import { SheetsProvider } from './SheetsContext'
 
 export default function App() {
@@ -19,6 +20,7 @@ export default function App() {
           <Route path="/award" element={<AwardScreen />} />
           <Route path="/award-display" element={<AwardDisplay />} />
           <Route path="/reports" element={<ReportScreen />} />
+          <Route path="/attendees" element={<AttendeeTable />} />
         </Routes>
       </Router>
     </SheetsProvider>

--- a/client/src/AttendeeTable.jsx
+++ b/client/src/AttendeeTable.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react'
+import { useSheets } from './SheetsContext'
+import './index.css'
+
+export default function AttendeeTable() {
+  const { getAllStudents } = useSheets()
+  const [students, setStudents] = useState([])
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    getAllStudents()
+      .then(data => {
+        const attended = data.filter(s => s.StudentAttended === 'Yes')
+        setStudents(attended)
+      })
+      .catch(err => console.error(err))
+  }, [getAllStudents])
+
+  const filtered = students.filter(s => {
+    const term = search.toLowerCase()
+    return (
+      s.ID.toString().includes(term) ||
+      `${s.Firstname} ${s.Lastname}`.toLowerCase().includes(term)
+    )
+  })
+
+  return (
+    <div className="container">
+      <h1>Attendees</h1>
+      <div className="form-controls">
+        <input
+          type="text"
+          placeholder="Search by ID or name"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+      </div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Gown Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map(s => (
+            <tr key={s.ID}>
+              <td>{s.ID}</td>
+              <td>{s.Firstname} {s.Lastname}</td>
+              <td>{s.GownStatus || 'Not Collected'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/client/src/Menu.jsx
+++ b/client/src/Menu.jsx
@@ -10,6 +10,7 @@ export default function Menu() {
       <Link to="/award">Awards</Link>
       <Link to="/award-display">Award Display</Link>
       <Link to="/reports">Reports</Link>
+      <Link to="/attendees">Attendees</Link>
     </nav>
   )
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -82,3 +82,15 @@ body {
   border-radius: 4px;
   margin-bottom: 0.5rem;
 }
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- add `AttendeeTable` page for viewing current attendees and gown status
- include new table styles
- register new route and nav link

## Testing
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_68711150ce2c832abcf93387c2c1f820