### PR TITLE
Add Ant Design components to all screens

### DIFF
--- a/client/src/AttendanceForm.jsx
+++ b/client/src/AttendanceForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { Input, InputNumber, Checkbox, Button, Alert } from 'antd'
 import { useSheets } from './SheetsContext'
 import './index.css'
 
@@ -99,11 +100,11 @@ export default function AttendanceForm() {
   return (
     <div className="container">
       <div className="form-controls">
-        <input
-          type="text"
+        <Input
           placeholder="Search by ID or name"
           value={search}
           onChange={e => setSearch(e.target.value)}
+          style={{ width: 200 }}
         />
       </div>
       <ul className="search-results">
@@ -118,33 +119,37 @@ export default function AttendanceForm() {
         <form onSubmit={handleSubmit} className="form">
           <label>
             Guest Number
-            <input
-              type="number"
+            <InputNumber
+              min={0}
               value={guestNumber}
-              onChange={e => setGuestNumber(Number(e.target.value))}
+              onChange={value => setGuestNumber(value)}
+              style={{ width: '100%' }}
             />
           </label>
           <label className="checkbox">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={studentAttended}
               onChange={e => setStudentAttended(e.target.checked)}
-            />
-            Student Attended
+            >
+              Student Attended
+            </Checkbox>
           </label>
           {photo && <img src={photo} alt="preview" className="photo" />}
           <label>
             Upload Photo
             <input type="file" accept="image/*" onChange={handlePhotoChange} />
           </label>
-          <button type="submit">Save</button>
+          <Button type="primary" htmlType="submit">Save</Button>
         </form>
       )}
 
       {message && (
-        <div className={message.type === 'error' ? 'msg error' : 'msg'}>
-          {message.text}
-        </div>
+        <Alert
+          type={message.type === 'error' ? 'error' : 'success'}
+          message={message.text}
+          showIcon
+          style={{ marginTop: '1rem' }}
+        />
       )}
     </div>
   )

--- a/client/src/AttendeeTable.jsx
+++ b/client/src/AttendeeTable.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { Table, Input } from 'antd'
 import { useSheets } from './SheetsContext'
 import './index.css'
 
@@ -28,31 +29,30 @@ export default function AttendeeTable() {
     <div className="container">
       <h1>Attendees</h1>
       <div className="form-controls">
-        <input
-          type="text"
+        <Input
           placeholder="Search by ID or name"
           value={search}
           onChange={e => setSearch(e.target.value)}
+          style={{ width: 200 }}
         />
       </div>
-      <table className="table">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Name</th>
-            <th>Gown Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map(s => (
-            <tr key={s.ID}>
-              <td>{s.ID}</td>
-              <td>{s.Firstname} {s.Lastname}</td>
-              <td>{s.GownStatus || 'Not Collected'}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <Table
+        dataSource={filtered}
+        rowKey="ID"
+        pagination={false}
+        className="table"
+        columns={[
+          { title: 'ID', dataIndex: 'ID' },
+          {
+            title: 'Name',
+            render: (_, s) => `${s.Firstname} ${s.Lastname}`
+          },
+          {
+            title: 'Gown Status',
+            render: (_, s) => s.GownStatus || 'Not Collected'
+          }
+        ]}
+      />
     </div>
   )
 }

--- a/client/src/AwardDisplay.jsx
+++ b/client/src/AwardDisplay.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
+import { Card } from 'antd'
 import { useSheets } from './SheetsContext'
 import './index.css'
 
@@ -33,14 +34,18 @@ export default function AwardDisplay() {
       <h1>Award Display</h1>
       <div className="grid">
         {students.map(s => (
-          <div key={s.ID} className="card">
-            {s.StudentPicture && (
-              <img src={s.StudentPicture} alt={s.Firstname} className="photo" />
-            )}
-            <h3>{s.Firstname} {s.Lastname}</h3>
-            <p>ID #{s.ID}</p>
+          <Card
+            key={s.ID}
+            className="card"
+            cover={
+              s.StudentPicture ? (
+                <img src={s.StudentPicture} alt={s.Firstname} className="photo" />
+              ) : null
+            }
+          >
+            <Card.Meta title={`${s.Firstname} ${s.Lastname}`} description={`ID #${s.ID}`} />
             <p>{s.Course}</p>
-          </div>
+          </Card>
         ))}
       </div>
     </div>

--- a/client/src/AwardScreen.jsx
+++ b/client/src/AwardScreen.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
+import { Card, Button } from 'antd'
 import { useSheets } from './SheetsContext'
 import './index.css'
 
@@ -39,15 +40,21 @@ export default function AwardScreen() {
       <h1>Award Collection</h1>
       <div className="grid">
         {students.map(s => (
-          <div key={s.ID} className="card">
-            {s.StudentPicture && (
-              <img src={s.StudentPicture} alt={s.Firstname} className="photo" />
-            )}
-            <h3>{s.Firstname} {s.Lastname}</h3>
-            <p>ID #{s.ID}</p>
+          <Card
+            key={s.ID}
+            className="card"
+            cover={
+              s.StudentPicture ? (
+                <img src={s.StudentPicture} alt={s.Firstname} className="photo" />
+              ) : null
+            }
+          >
+            <Card.Meta title={`${s.Firstname} ${s.Lastname}`} description={`ID #${s.ID}`} />
             <p>{s.Course}</p>
-            <button onClick={() => markCollected(s.ID)}>Mark Certificate Collected</button>
-          </div>
+            <Button onClick={() => markCollected(s.ID)} style={{ marginTop: 8 }}>
+              Mark Certificate Collected
+            </Button>
+          </Card>
         ))}
       </div>
     </div>

--- a/client/src/Menu.jsx
+++ b/client/src/Menu.jsx
@@ -1,16 +1,25 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
+import { Menu } from 'antd'
 import './index.css'
 
-export default function Menu() {
+export default function MenuComponent() {
+  const location = useLocation()
+  const items = [
+    { label: <Link to="/">Attendance</Link>, key: '/' },
+    { label: <Link to="/gown">Gown Mgmt</Link>, key: '/gown' },
+    { label: <Link to="/award">Awards</Link>, key: '/award' },
+    { label: <Link to="/award-display">Award Display</Link>, key: '/award-display' },
+    { label: <Link to="/reports">Reports</Link>, key: '/reports' },
+    { label: <Link to="/attendees">Attendees</Link>, key: '/attendees' }
+  ]
+
   return (
-    <nav className="menu">
-      <Link to="/">Attendance</Link>
-      <Link to="/gown">Gown Mgmt</Link>
-      <Link to="/award">Awards</Link>
-      <Link to="/award-display">Award Display</Link>
-      <Link to="/reports">Reports</Link>
-      <Link to="/attendees">Attendees</Link>
-    </nav>
+    <Menu
+      mode="horizontal"
+      selectedKeys={[location.pathname]}
+      items={items}
+      className="menu"
+    />
   )
 }

--- a/client/src/ReportScreen.jsx
+++ b/client/src/ReportScreen.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { Alert, List } from 'antd'
 import { useSheets } from './SheetsContext'
 import './index.css'
 
@@ -28,7 +29,7 @@ export default function ReportScreen() {
   if (error) {
     return (
       <div className="container">
-        <div className="msg error">{error}</div>
+        <Alert type="error" message={error} showIcon />
       </div>
     )
   }
@@ -40,13 +41,13 @@ export default function ReportScreen() {
   return (
     <div className="container">
       <h1>Reports</h1>
-      <ul className="list">
-        <li className="list-item">Students Attended: {stats.totalStudents}</li>
-        <li className="list-item">Guests Present: {stats.totalGuests}</li>
-        <li className="list-item">Total Present: {stats.totalTotal}</li>
-        <li className="list-item">Gowns Collected: {stats.gownsCollected}</li>
-        <li className="list-item">Gowns Returned: {stats.gownsReturned}</li>
-      </ul>
+      <List bordered className="list">
+        <List.Item>Students Attended: {stats.totalStudents}</List.Item>
+        <List.Item>Guests Present: {stats.totalGuests}</List.Item>
+        <List.Item>Total Present: {stats.totalTotal}</List.Item>
+        <List.Item>Gowns Collected: {stats.gownsCollected}</List.Item>
+        <List.Item>Gowns Returned: {stats.gownsReturned}</List.Item>
+      </List>
     </div>
   )
 }

--- a/client/src/StudentList.jsx
+++ b/client/src/StudentList.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { List } from 'antd'
 import './index.css'
 
 export default function StudentList() {
@@ -14,13 +15,15 @@ export default function StudentList() {
   return (
     <div className="container">
       <h1>Student List</h1>
-      <ul className="list">
-        {students.map(student => (
-          <li key={student.ID} className="list-item">
+      <List
+        bordered
+        dataSource={students}
+        renderItem={student => (
+          <List.Item key={student.ID} className="list-item">
             {student.Firstname} {student.Lastname} - {student.Course}
-          </li>
-        ))}
-      </ul>
+          </List.Item>
+        )}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- switch Menu navigation to Ant Design `Menu`
- convert AttendanceForm to Ant Design inputs and alerts
- use Ant Design Card for award screens
- display reports, attendees, and students with Ant Design components

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871186622e0832a81b56ea7f9af61fe