### PR TITLE
Improve award display sizing

### DIFF
--- a/client/src/AwardDisplay.jsx
+++ b/client/src/AwardDisplay.jsx
@@ -30,16 +30,16 @@ export default function AwardDisplay() {
   }, [loadStudents])
 
   return (
-    <div className="container">
+    <div className="display-container">
       <h1>Award Display</h1>
-      <div className="grid">
+      <div className="display-grid">
         {students.map(s => (
           <Card
             key={s.ID}
-            className="card"
+            className="display-card"
             cover={
               s.StudentPicture ? (
-                <img src={s.StudentPicture} alt={s.Firstname} className="photo" />
+                <img src={s.StudentPicture} alt={s.Firstname} className="display-photo" />
               ) : null
             }
           >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -126,3 +126,41 @@ body {
   padding: 0.5rem;
   text-align: left;
 }
+
+/* Styles for AwardDisplay TV/Prompter view */
+.display-container {
+  width: 100%;
+  margin: 0;
+  padding: 1rem 2rem;
+}
+
+.display-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.display-card {
+  border: 1px solid #ddd;
+  padding: 1.5rem;
+  border-radius: 8px;
+  width: 300px;
+  font-size: 1.25rem;
+}
+
+.display-photo {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.display-card .ant-card-meta-title {
+  font-size: 1.5rem;
+}
+
+.display-card .ant-card-meta-description,
+.display-card p {
+  font-size: 1.25rem;
+}


### PR DESCRIPTION
## Summary
- enlarge AwardDisplay cards for TV/presenter view
- add dedicated CSS classes for larger layout

## Testing
- `npm --prefix client install`
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_68711ee14b44832abf0ee38a728c1502