### PR TITLE
Add camera capture option for Attendance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 # Expo
 .expo/
 dist/
+client/dist/
 web-build/
 expo-env.d.ts
 .env

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -168,3 +168,16 @@ body {
 .display-card p {
   font-size: 1.25rem;
 }
+
+.camera {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.camera video {
+  width: 100%;
+  max-width: 400px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- enable camera capture in `AttendanceForm`
- style video display
- ignore frontend build output

## Testing
- `npm --prefix client install`
- `npm --prefix client run build`
- `npm install`
- `npm start` *(fails: ENOENT service-account.json)*

------
https://chatgpt.com/codex/tasks/task_e_6874eeedc36c832a9bbb2ae3a8b7a8c1