### PR TITLE
Fix award course display

### DIFF
--- a/client/src/AwardDisplay.jsx
+++ b/client/src/AwardDisplay.jsx
@@ -44,7 +44,7 @@ export default function AwardDisplay() {
             }
           >
             <Card.Meta title={`${s.Firstname} ${s.Lastname}`} description={`ID #${s.ID}`} />
-            <p>{s.Course}</p>
+            <p>{s.Course.split(/[\/,]/)[0].trim()}</p>
           </Card>
         ))}
       </div>

--- a/client/src/AwardDisplaySingle.jsx
+++ b/client/src/AwardDisplaySingle.jsx
@@ -44,7 +44,7 @@ export default function AwardDisplaySingle() {
             }
           >
             <Card.Meta title={`${s.Firstname} ${s.Lastname}`} description={`ID #${s.ID}`} />
-            <p>{s.Course}</p>
+            <p>{s.Course.split(/[\/,]/)[0].trim()}</p>
           </Card>
         ))}
       </div>

--- a/client/src/AwardScreen.jsx
+++ b/client/src/AwardScreen.jsx
@@ -52,7 +52,7 @@ export default function AwardScreen() {
             }
           >
             <Card.Meta title={`${s.Firstname} ${s.Lastname}`} description={`ID #${s.ID}`} />
-            <p>{s.Course}</p>
+            <p>{s.Course.split(/[\/,]/)[0].trim()}</p>
             <Button onClick={() => markCollected(s.ID)} style={{ marginTop: 8 }}>
               Mark Certificate Collected
             </Button>


### PR DESCRIPTION
## Summary
- show only the first course for awards by splitting on `/` or `,`

## Testing
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_68750f616488832a8efb7508d4e57739