### PR TITLE
Add logo and collapsible menu

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,6 +14,11 @@ export default function App() {
   return (
     <SheetsProvider>
       <Router>
+        <img
+          src="https://study.spa.edu.tt/images/spa-logo-rec.png"
+          alt="SPA Logo"
+          className="logo"
+        />
         <Menu />
         <Routes>
           <Route path="/" element={<AttendanceForm />} />

--- a/client/src/Menu.jsx
+++ b/client/src/Menu.jsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { Menu } from 'antd'
+import { Menu, Button } from 'antd'
 import './index.css'
 
 export default function MenuComponent() {
   const location = useLocation()
+  const [open, setOpen] = useState(false)
   const items = [
     { label: <Link to="/">Attendance</Link>, key: '/' },
     { label: <Link to="/gown">Gown Mgmt</Link>, key: '/gown' },
@@ -16,11 +17,19 @@ export default function MenuComponent() {
   ]
 
   return (
-    <Menu
-      mode="horizontal"
-      selectedKeys={[location.pathname]}
-      items={items}
-      className="menu"
-    />
+    <div className="menu-wrapper">
+      <Button className="menu-toggle" onClick={() => setOpen(!open)}>
+        Menu
+      </Button>
+      {open && (
+        <Menu
+          mode="horizontal"
+          selectedKeys={[location.pathname]}
+          items={items}
+          onClick={() => setOpen(false)}
+          className="menu"
+        />
+      )}
+    </div>
   )
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -8,6 +8,20 @@ a {
   margin-bottom: 1.5rem;
 }
 
+.menu-wrapper {
+  text-align: center;
+}
+
+.menu-toggle {
+  margin-bottom: 0.5rem;
+}
+
+.logo {
+  display: block;
+  margin: 0 auto 1rem;
+  max-width: 200px;
+}
+
 .container {
   max-width: 800px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- show the SPA logo at the top of the page
- toggle menu visibility with a button

## Testing
- `npm --prefix client install`
- `npm --prefix client run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68766e9a8f88832aaf91f127cb25993e