### PR TITLE
Add realtime attendee updates via SSE

### DIFF
--- a/client/src/AttendeeTable.jsx
+++ b/client/src/AttendeeTable.jsx
@@ -9,12 +9,23 @@ export default function AttendeeTable() {
   const [search, setSearch] = useState('')
 
   useEffect(() => {
-    getAllStudents()
-      .then(data => {
-        const attended = data.filter(s => s.StudentAttended === 'Yes')
-        setStudents(attended)
-      })
-      .catch(err => console.error(err))
+    const fetchData = () => {
+      getAllStudents()
+        .then(data => {
+          const attended = data.filter(s => s.StudentAttended === 'Yes')
+          setStudents(attended)
+        })
+        .catch(err => console.error(err))
+    }
+
+    fetchData()
+
+    const source = new EventSource('/events')
+    source.onmessage = () => fetchData()
+
+    return () => {
+      source.close()
+    }
   }, [getAllStudents])
 
   const filtered = students.filter(s => {


### PR DESCRIPTION
## Summary
- implement Server-Sent Events endpoint to push updates
- broadcast update from server when student data changes
- listen for SSE events on AttendeeTable and refresh data

## Testing
- `npm install`
- `npm start` *(fails: ENOENT: no such file or directory 'service-account.json')*

------
https://chatgpt.com/codex/tasks/task_e_6876a90fbc90832ab9996bea3e054bcc