### PR TITLE
Fix dev SSE proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This project provides a simple interface to view student information stored in a
    npm start
    ```
    The Express API runs on port `3000` and the React application on port `5173`.
+   The dev server proxies both `/api` and `/events` to the Express backend so
+   that server-sent events work during development.
 
 3. Build the frontend for production:
    ```bash

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,7 +5,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/api': 'http://localhost:3000'
+      '/api': 'http://localhost:3000',
+      '/events': 'http://localhost:3000'
     },
     allowedHosts: ['graduation.spa.edu.tt']
   }


### PR DESCRIPTION
## Summary
- proxy `/events` to the API for dev server
- document SSE proxy in the setup instructions

## Testing
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_6877524c01d0832a9c4654bde2cef495