### PR TITLE
Add photo package management form

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import AwardDisplay from './AwardDisplay'
 import AwardDisplaySingle from './AwardDisplaySingle'
 import ReportScreen from './ReportScreen'
 import AttendeeTable from './AttendeeTable'
+import PhotoPackageForm from './PhotoPackageForm'
 import { SheetsProvider } from './SheetsContext'
 
 export default function App() {
@@ -26,6 +27,7 @@ export default function App() {
           <Route path="/award" element={<AwardScreen />} />
           <Route path="/award-display" element={<AwardDisplay />} />
           <Route path="/award-display-single" element={<AwardDisplaySingle />} />
+          <Route path="/photos" element={<PhotoPackageForm />} />
           <Route path="/reports" element={<ReportScreen />} />
           <Route path="/attendees" element={<AttendeeTable />} />
         </Routes>

--- a/client/src/Menu.jsx
+++ b/client/src/Menu.jsx
@@ -12,6 +12,7 @@ export default function MenuComponent() {
     { label: <Link to="/award">Awards</Link>, key: '/award' },
     { label: <Link to="/award-display">Award Display</Link>, key: '/award-display' },
     { label: <Link to="/award-display-single">Award Display (Single)</Link>, key: '/award-display-single' },
+    { label: <Link to="/photos">Photos</Link>, key: '/photos' },
     { label: <Link to="/reports">Reports</Link>, key: '/reports' },
     { label: <Link to="/attendees">Attendees</Link>, key: '/attendees' }
   ]

--- a/client/src/PhotoPackageForm.jsx
+++ b/client/src/PhotoPackageForm.jsx
@@ -1,0 +1,180 @@
+import React, { useEffect, useState } from 'react'
+import { Input, Select, Button, Alert } from 'antd'
+import { useSheets } from './SheetsContext'
+import './index.css'
+
+const PACKAGES = [
+  {
+    name: 'Package 1',
+    description: '2-4x6 Stage Photos (Medal & Trophy)',
+    prints: 40,
+    digital: 20
+  },
+  {
+    name: 'Package 2',
+    description: '2-4x6 Stage photos (Medal & Trophy); 1 -8x10 Family/solo shot',
+    prints: 80,
+    digital: 40
+  },
+  {
+    name: 'Package 3',
+    description: '2-8x10 Stage photos (Medal & Trophy)',
+    prints: 80,
+    digital: 40
+  },
+  {
+    name: 'Package 4',
+    description: '2-4x6 Stage Photos (Medal & Trophy); 1 4x6 (Family/Solo shot); 1 8x10 (Family/Solo shot)',
+    prints: 100,
+    digital: 50
+  }
+]
+
+export default function PhotoPackageForm() {
+  const { getAllStudents, getStudentById, updateStudentField } = useSheets()
+  const [students, setStudents] = useState([])
+  const [search, setSearch] = useState('')
+  const [open, setOpen] = useState(false)
+  const [selectedId, setSelectedId] = useState('')
+  const [student, setStudent] = useState(null)
+  const [pkg, setPkg] = useState(PACKAGES[0].name)
+  const [pkgType, setPkgType] = useState('Print')
+  const [paymentStatus, setPaymentStatus] = useState('Not Paid')
+  const [pkgStatus, setPkgStatus] = useState('Not Collected')
+  const [message, setMessage] = useState(null)
+
+  useEffect(() => {
+    getAllStudents()
+      .then(setStudents)
+      .catch(() => setMessage({ type: 'error', text: 'Failed to load students' }))
+  }, [getAllStudents])
+
+  useEffect(() => {
+    if (search) setOpen(true)
+    else setOpen(false)
+  }, [search])
+
+  const filtered = students.filter(s => {
+    const term = search.toLowerCase()
+    return (
+      s.ID.toString().includes(term) ||
+      `${s.Firstname} ${s.Lastname}`.toLowerCase().includes(term)
+    )
+  })
+
+  const loadStudent = id => {
+    getStudentById(id)
+      .then(data => {
+        setStudent(data)
+        setPkg(data['Photo Package'] || PACKAGES[0].name)
+        setPkgType(data['Photo Package Type'] || 'Print')
+        setPaymentStatus(data['Photo Payment Status'] || 'Not Paid')
+        setPkgStatus(data['Photo Package Status'] || 'Not Collected')
+      })
+      .catch(() => setMessage({ type: 'error', text: 'Failed to load student' }))
+  }
+
+  const handleSelect = value => {
+    setSelectedId(value)
+    if (value) loadStudent(value)
+    else setStudent(null)
+    setOpen(false)
+  }
+
+  const selectedPackage = PACKAGES.find(p => p.name === pkg)
+  const price = pkgType === 'Digital' ? selectedPackage.digital : selectedPackage.prints
+
+  const updateFields = updates => {
+    setMessage(null)
+    const promises = Object.entries(updates).map(([field, value]) =>
+      updateStudentField(selectedId, field, value)
+    )
+    Promise.all(promises)
+      .then(() => loadStudent(selectedId))
+      .then(() => setMessage({ type: 'success', text: 'Saved successfully' }))
+      .catch(() => setMessage({ type: 'error', text: 'Failed to save changes' }))
+  }
+
+  const handleSave = e => {
+    e.preventDefault()
+    updateFields({
+      'Photo Package': pkg,
+      'Photo Package Type': pkgType,
+      'Photo Payment Status': paymentStatus,
+      'Photo Package Status': pkgStatus
+    })
+  }
+
+  return (
+    <div className="container">
+      <div className="form-controls">
+        <Input
+          placeholder="Search by ID or name"
+          value={search}
+          onChange={e => {
+            setSearch(e.target.value)
+            setOpen(true)
+          }}
+          style={{ width: 200 }}
+        />
+        <Select
+          value={selectedId || undefined}
+          onChange={handleSelect}
+          placeholder="Select a student"
+          style={{ minWidth: 220 }}
+          allowClear
+          options={filtered.map(s => ({ value: s.ID, label: `${s.ID} - ${s.Firstname} ${s.Lastname}` }))}
+          open={open}
+          onDropdownVisibleChange={vis => setOpen(vis)}
+        />
+      </div>
+
+      {student && (
+        <form onSubmit={handleSave} className="form">
+          <label>
+            Photo Package
+            <Select value={pkg} onChange={setPkg} style={{ width: 200 }}>
+              {PACKAGES.map(p => (
+                <Select.Option key={p.name} value={p.name}>
+                  {p.name}
+                </Select.Option>
+              ))}
+            </Select>
+          </label>
+          <label>
+            Package Type
+            <Select value={pkgType} onChange={setPkgType} style={{ width: 120 }}>
+              <Select.Option value="Print">Print</Select.Option>
+              <Select.Option value="Digital">Digital</Select.Option>
+            </Select>
+          </label>
+          <p>Price: ${price.toFixed(2)}</p>
+          <label>
+            Payment Status
+            <Select value={paymentStatus} onChange={setPaymentStatus} style={{ width: 150 }}>
+              <Select.Option value="Not Paid">Not Paid</Select.Option>
+              <Select.Option value="Paid">Paid</Select.Option>
+            </Select>
+          </label>
+          <label>
+            Package Status
+            <Select value={pkgStatus} onChange={setPkgStatus} style={{ width: 150 }}>
+              <Select.Option value="Not Collected">Not Collected</Select.Option>
+              <Select.Option value="Collected">Collected</Select.Option>
+            </Select>
+          </label>
+          <Button type="primary" htmlType="submit">Save</Button>
+        </form>
+      )}
+
+      {message && (
+        <Alert
+          type={message.type === 'error' ? 'error' : 'success'}
+          message={message.text}
+          showIcon
+          style={{ marginTop: '1rem' }}
+        />
+      )}
+    </div>
+  )
+}

--- a/server.js
+++ b/server.js
@@ -92,6 +92,18 @@ app.put('/api/students/:id', async (req, res) => {
     if (req.body.AwardStatus !== undefined) {
       updates.push(updateStudentField(id, 'AwardStatus', req.body.AwardStatus));
     }
+    if (req.body['Photo Package'] !== undefined) {
+      updates.push(updateStudentField(id, 'Photo Package', req.body['Photo Package']));
+    }
+    if (req.body['Photo Package Type'] !== undefined) {
+      updates.push(updateStudentField(id, 'Photo Package Type', req.body['Photo Package Type']));
+    }
+    if (req.body['Photo Payment Status'] !== undefined) {
+      updates.push(updateStudentField(id, 'Photo Payment Status', req.body['Photo Payment Status']));
+    }
+    if (req.body['Photo Package Status'] !== undefined) {
+      updates.push(updateStudentField(id, 'Photo Package Status', req.body['Photo Package Status']));
+    }
     await Promise.all(updates);
     const student = await getStudentById(id);
     res.json(student);

--- a/sheets.js
+++ b/sheets.js
@@ -18,6 +18,10 @@ const { google } = require('googleapis');
  * @property {string} [Email]
  * @property {string} [Phone]
  * @property {('Collected'|null)} [AwardStatus]
+ * @property {string} ["Photo Package"]
+ * @property {('Print'|'Digital')} ["Photo Package Type"]
+ * @property {('Paid'|'Not Paid')} ["Photo Payment Status"]
+ * @property {('Collected'|'Not Collected')} ["Photo Package Status"]
  */
 
 const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
@@ -61,7 +65,11 @@ const HEADERS = [
   'StudentPicture',
   'Email',
   'Phone',
-  'AwardStatus'
+  'AwardStatus',
+  'Photo Package',
+  'Photo Package Type',
+  'Photo Payment Status',
+  'Photo Package Status'
 ];
 
 const COLUMN_MAP = HEADERS.reduce((map, header, i) => {


### PR DESCRIPTION
## Summary
- extend Google Sheets columns to handle photo package information
- update server to save photo package fields
- add PhotoPackageForm React component
- wire the new page into routing and menu

## Testing
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_68775738d1ac832ab3812ea5183c1e68