### PR TITLE
Add live photo packages table

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,6 @@ The application includes several screens accessible via the menu. Alongside the
 existing Award Display that cycles through the next three awards, there is now a
 **Single Award Display** page available at `/award-display-single` which shows
 only the next student.
+
+There is also a **Photo Packages** table available at `/photo-packages` that
+lists purchased packages with live updates.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import AwardDisplaySingle from './AwardDisplaySingle'
 import ReportScreen from './ReportScreen'
 import AttendeeTable from './AttendeeTable'
 import PhotoPackageForm from './PhotoPackageForm'
+import PhotoPackagesTable from './PhotoPackagesTable'
 import { SheetsProvider } from './SheetsContext'
 
 export default function App() {
@@ -28,6 +29,7 @@ export default function App() {
           <Route path="/award-display" element={<AwardDisplay />} />
           <Route path="/award-display-single" element={<AwardDisplaySingle />} />
           <Route path="/photos" element={<PhotoPackageForm />} />
+          <Route path="/photo-packages" element={<PhotoPackagesTable />} />
           <Route path="/reports" element={<ReportScreen />} />
           <Route path="/attendees" element={<AttendeeTable />} />
         </Routes>

--- a/client/src/Menu.jsx
+++ b/client/src/Menu.jsx
@@ -13,6 +13,7 @@ export default function MenuComponent() {
     { label: <Link to="/award-display">Award Display</Link>, key: '/award-display' },
     { label: <Link to="/award-display-single">Award Display (Single)</Link>, key: '/award-display-single' },
     { label: <Link to="/photos">Photos</Link>, key: '/photos' },
+    { label: <Link to="/photo-packages">Photo Packages</Link>, key: '/photo-packages' },
     { label: <Link to="/reports">Reports</Link>, key: '/reports' },
     { label: <Link to="/attendees">Attendees</Link>, key: '/attendees' }
   ]

--- a/client/src/PhotoPackagesTable.jsx
+++ b/client/src/PhotoPackagesTable.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react'
+import { Table, Input } from 'antd'
+import { useSheets } from './SheetsContext'
+import './index.css'
+
+export default function PhotoPackagesTable() {
+  const { getAllStudents } = useSheets()
+  const [students, setStudents] = useState([])
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    const fetchData = () => {
+      getAllStudents()
+        .then(data => {
+          const withPackages = data.filter(s => s['Photo Package'])
+          setStudents(withPackages)
+        })
+        .catch(err => console.error(err))
+    }
+
+    fetchData()
+
+    const source = new EventSource('/events')
+    source.onmessage = () => fetchData()
+
+    return () => {
+      source.close()
+    }
+  }, [getAllStudents])
+
+  const filtered = students.filter(s => {
+    const term = search.toLowerCase()
+    return (
+      s.ID.toString().includes(term) ||
+      `${s.Firstname} ${s.Lastname}`.toLowerCase().includes(term)
+    )
+  })
+
+  const columns = [
+    {
+      title: 'Name',
+      render: (_, s) => `${s.Firstname} ${s.Lastname}`
+    },
+    {
+      title: 'Photo Package',
+      dataIndex: 'Photo Package'
+    },
+    {
+      title: 'Package Type',
+      dataIndex: 'Photo Package Type'
+    },
+    {
+      title: 'Payment Status',
+      dataIndex: 'Photo Payment Status'
+    }
+  ]
+
+  return (
+    <div className="container">
+      <div className="form-controls">
+        <Input
+          placeholder="Search by ID or name"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{ width: 200 }}
+        />
+      </div>
+      <Table
+        dataSource={filtered}
+        rowKey="ID"
+        pagination={false}
+        className="table"
+        columns={columns}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show live table of photo package purchases
- link to the new table in the menu
- route `/photo-packages` to the new screen
- document the photo packages screen in the README

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_68775ba87838832ab6c9b005cf1b4283